### PR TITLE
removed the need for bower install (after npm install)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ git clone https://github.com/neojp/TodoMVC-EAK.git
 cd TodoMVC-EAK
 npm install -g grunt-cli bower
 npm install
-bower install
 grunt server
 ```
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "test"
   },
   "scripts": {
+    "postinstall": "bower install",
     "start": "grunt server",
     "build": "grunt build:debug",
     "test": "grunt test:ci"


### PR DESCRIPTION
I've found that having a simple postinstall hook keeps the README a little simpler for new devs
